### PR TITLE
adding functions for test, build and install (python only)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,14 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.0.0
+    hooks:
+    -   id: trailing-whitespace
+    -   id: end-of-file-fixer
+    -   id: check-yaml
+    -   id: check-added-large-files
+-   repo: https://github.com/psf/black
+    rev: 19.3b0
+    hooks:
+    -   id: black

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,8 @@ cache:
     - $HOME/.cache/pip
 
 python:
-  - 3.6
   - 3.7
-  - 3.8-dev
+  - 3.8
 
 env:
   global:
@@ -64,7 +63,7 @@ before_script:
 script:
   - |
     if [ "$CHECK" = "style" ]; then
-        black --check --py36 --exclude templates/python setup.py niflow_manager
+        black --check --exclude templates/python setup.py niflow_manager
     elif [ "$CHECK" = "test" ]; then
         py.test -v -s --cov niflow_manager --cov-report xml:cov.xml --doctest-modules niflow_manager
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,7 @@ script:
     if [ "$CHECK" = "style" ]; then
         black --check --exclude templates/python setup.py niflow_manager
     elif [ "$CHECK" = "test" ]; then
-        py.test -v -s --cov niflow_manager --cov-report xml:cov.xml --doctest-modules niflow_manager
+        py.test -v -s --cov niflow_manager --cov-config setup.cfg --cov-report xml:cov.xml --doctest-modules niflow_manager
     fi
 
 after_script:

--- a/niflow_manager/cli/build.py
+++ b/niflow_manager/cli/build.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+import subprocess as sp
+import tempfile, os, json
+from pathlib import Path
+from copy import deepcopy
+import yaml
+import neurodocker as ndr
+
+# default setting for specific neurodocker keys,
+# this value will not have to be set in the parameters.yml, but can be overwritten
+DEFAULT_INSTRUCTIONS = {
+    "miniconda": {'create_env': 'testkraken', 'activate': True}
+}
+# all keys allowed by neurodocker for Docker
+VALID_DOCKER_KEYS = ndr.Dockerfile._implementations.keys()
+
+
+def neurodocker_dict(workflow_path):
+    """reading spec.yml and creating neurodocker dict
+        for the environment defined in the requirements and post_build parts
+    """
+    with (workflow_path / 'spec.yml').open() as f:
+        params = yaml.safe_load(f)
+    instructions = []
+
+    # treating requirement as one env spec
+    params_env = params["requirements"]
+    if "base" not in params_env.keys():
+        raise ValueError("base image has to be provided")
+
+    miniconda_env = None
+    for key, spec in params_env.items():
+        if key == "base":
+            base_image = spec.get('image', None)
+            if base_image is None:
+                raise Exception("image has to be provided in base")
+            this_instruction = ('base', base_image)
+            pkg_manager = spec.get('pkg_manager', None)
+            if pkg_manager is None:
+                if base_image in ["centos", "fedora"]:
+                    pkg_manager = 'yum'
+                else:
+                    pkg_manager = 'apt'  # assume apt
+        elif key in VALID_DOCKER_KEYS:
+            spec_final = deepcopy(DEFAULT_INSTRUCTIONS.get(key, {}))
+            spec_final.update(spec)
+            this_instruction = (key, spec_final)
+            if key == "miniconda":
+                miniconda_env = spec_final["create_env"]
+        else:
+            raise Exception(f"{key} is not a valid key, must be "
+                            f"from the list {VALID_DOCKER_KEYS}")
+        instructions.append(this_instruction)
+
+    # adding post build part
+    post_build = params.get("post_build", {})
+    if not post_build:
+        # if post build not provided, it will use the default one that installs niflow-manager
+        # and the package (after coping it first)
+        post_build["copy"] = [".", "/nfm"]
+        post_build["miniconda"] = {"pip_install": ["niflow-manager", "/nfm/package/"]}
+
+    for key, spec in post_build.items():
+        if key == "miniconda":
+            if miniconda_env:
+                miniconda_dict = {"use_env": miniconda_env}
+            else:
+                miniconda_dict = {"create_env": "testkraken"}
+            miniconda_dict.update(spec)
+            instructions.append(("miniconda", miniconda_dict))
+        else:
+            instructions.append((key, spec))
+
+    return {
+        "pkg_manager": pkg_manager,
+        "instructions": tuple(instructions),
+    }
+
+def write_dockerfile_sp(nrd_jsonfile, dockerfile):
+    """ Generate and write Dockerfile to `dockerfile`, uses Neurodocker cli
+        These is a tmp function, would prefer to use write_dockerfile
+    """
+    nrd_args = ["neurodocker", "generate", "docker", nrd_jsonfile,
+                "-o", dockerfile, "--no-print", "--json"]
+    # not sure if I need to use out_json anywhere, might remove "--json"
+    out_json = sp.run(
+                nrd_args,
+                check=True,
+                stdout=sp.PIPE).stdout.decode()
+
+
+def build_image(dockerfile, workflow_path, tag=None, build_opts=None):
+    """Build Docker image. TODO
+
+    Parameters
+    ----------
+    dockerfile : path-like
+        Path to Dockerfile. May be absolute or relative. If `build_context`
+        if provided, `dockerfile` is joined to `build_context`.
+    workflow_path : path-like
+        Path to workflow that will be used as a build context.
+    tag : str
+        Docker image tag. E.g., "kaczmarj/myimage:v0.1.0".
+    build_opts : str
+        String of options to pass to `docker build`.
+    """
+    tag = '' if tag is None else "-t {}".format(tag)
+    build_opts = '' if build_opts is None else build_opts
+
+    cmd_base = "docker build {tag} {build_opts}"
+    cmd = cmd_base.format(tag=tag, build_opts=build_opts)
+
+    build_context = workflow_path
+    # changing build directory, needed for fnp
+    # was failing wit providing build_context to build command)
+    cwd = os.getcwd()
+    os.chdir(build_context)
+    cmd += " -f {} .".format(dockerfile)
+
+    sp.run(cmd.split(), check=True)
+    os.chdir(cwd)
+
+
+
+def docker_image(workflow_path, working_dir=None):
+    """the main function to create Dockerfile and build the image"""
+    workflow_path = Path(workflow_path)
+    if working_dir:
+        working_dir = Path(working_dir).absolute()
+    else:
+        working_dir = Path(tempfile.mkdtemp(
+        prefix=f'nfm-{workflow_path.name}')).absolute()
+    dockerfile = working_dir / 'Dockerfile'
+    if dockerfile.exists():
+        dockerfile.unlink()
+    jsonfile = working_dir / f"nrd_spec.json"
+    if jsonfile.exists():
+        jsonfile.exists()
+
+    nrd_dict = neurodocker_dict(workflow_path=workflow_path)
+    with open(jsonfile, 'w') as fj:
+        json.dump(nrd_dict, fj)
+
+    write_dockerfile_sp(nrd_jsonfile=jsonfile, dockerfile=dockerfile)
+    build_image(dockerfile=dockerfile, workflow_path=workflow_path, tag=f"nfm-{workflow_path.name}")

--- a/niflow_manager/cli/build.py
+++ b/niflow_manager/cli/build.py
@@ -139,7 +139,7 @@ def build_image(dockerfile, workflow_path, tag=None, build_opts=None):
 
 def docker_image(workflow_path, working_dir=None):
     """the main function to create Dockerfile and build the image"""
-    workflow_path = Path(workflow_path)
+    workflow_path = Path(workflow_path).absolute()
     if working_dir:
         working_dir = Path(working_dir).absolute()
     else:

--- a/niflow_manager/cli/build.py
+++ b/niflow_manager/cli/build.py
@@ -69,7 +69,7 @@ def neurodocker_dict(workflow_path):
         }
         post_build[
             "run_bash"
-        ] = "/opt/miniconda-latest/envs/testkraken/bin/nfm install /nfm/package/"
+        ] = "/opt/miniconda-latest/envs/testkraken/bin/nfm install /nfm"
         post_build[
             "entrypoint"
         ] = f"/opt/miniconda-latest/envs/testkraken/bin/{workflow_path.name}"

--- a/niflow_manager/cli/build.py
+++ b/niflow_manager/cli/build.py
@@ -4,6 +4,7 @@ import tempfile, os, json
 from pathlib import Path
 from copy import deepcopy
 import yaml
+import click
 import neurodocker as ndr
 
 # default setting for specific neurodocker keys,
@@ -163,3 +164,15 @@ def docker_image(workflow_path, working_dir=None):
         workflow_path=workflow_path,
         tag=f"nfm-{workflow_path.name}",
     )
+
+
+@click.argument("workflow_path", type=click.Path(), default=".")
+@click.option(
+    "-w",
+    "--working-dir",
+    type=click.Path(),
+    help="Working directory, default is a temporary directory.",
+)
+def build(workflow_path, working_dir=None):
+    print("build", workflow_path)
+    docker_image(workflow_path=workflow_path, working_dir=working_dir)

--- a/niflow_manager/cli/build.py
+++ b/niflow_manager/cli/build.py
@@ -61,6 +61,7 @@ def neurodocker_dict(workflow_path):
         post_build["copy"] = [".", "/nfm"]
         post_build["miniconda"] = {"pip_install": ["https://github.com/djarecka/niflow-manager/tarball/new_testkraken"]}
         post_build["run_bash"] = "/opt/miniconda-latest/envs/testkraken/bin/nfm install /nfm/package/"
+        post_build["entrypoint"] = f"/opt/miniconda-latest/envs/testkraken/bin/niflow-{workflow_path.name}"
 
     for key, spec in post_build.items():
         if key == "miniconda":

--- a/niflow_manager/cli/build.py
+++ b/niflow_manager/cli/build.py
@@ -72,7 +72,7 @@ def neurodocker_dict(workflow_path):
         ] = "/opt/miniconda-latest/envs/testkraken/bin/nfm install /nfm/package/"
         post_build[
             "entrypoint"
-        ] = f"/opt/miniconda-latest/envs/testkraken/bin/niflow-{workflow_path.name}"
+        ] = f"/opt/miniconda-latest/envs/testkraken/bin/{workflow_path.name}"
 
     for key, spec in post_build.items():
         if key == "miniconda":

--- a/niflow_manager/cli/build.py
+++ b/niflow_manager/cli/build.py
@@ -9,7 +9,7 @@ import neurodocker as ndr
 
 # default setting for specific neurodocker keys,
 # this value will not have to be set in the parameters.yml, but can be overwritten
-DEFAULT_INSTRUCTIONS = {"miniconda": {"create_env": "testkraken", "activate": True}}
+DEFAULT_INSTRUCTIONS = {"miniconda": {"create_env": "niflows", "activate": True}}
 # all keys allowed by neurodocker for Docker
 VALID_DOCKER_KEYS = ndr.Dockerfile._implementations.keys()
 
@@ -77,21 +77,21 @@ def neurodocker_dict(workflow_path):
         # installing niflow
         post_build[
             "run_bash"
-        ] = "/opt/miniconda-latest/envs/testkraken/bin/nfm install /nfm"
+        ] = "/opt/miniconda-latest/envs/niflows/bin/nfm install /nfm"
         # adding entrypoint to the container
         if params_entry:
             post_build["entrypoint"] = params_entry
         else:
             post_build[
                 "entrypoint"
-            ] = f"/opt/miniconda-latest/envs/testkraken/bin/{workflow_path.name}"
+            ] = f"/opt/miniconda-latest/envs/niflows/bin/{workflow_path.name}"
 
     for key, spec in post_build.items():
         if key == "miniconda":
             if miniconda_env:
                 miniconda_dict = {"use_env": miniconda_env}
             else:
-                miniconda_dict = {"create_env": "testkraken"}
+                miniconda_dict = {"create_env": "niflows"}
             miniconda_dict.update(spec)
             instructions.append(("miniconda", miniconda_dict))
         else:
@@ -164,7 +164,7 @@ def docker_image(workflow_path, working_dir=None):
         dockerfile.unlink()
     jsonfile = working_dir / f"nrd_spec.json"
     if jsonfile.exists():
-        jsonfile.exists()
+        jsonfile.unlink()
 
     nrd_dict = neurodocker_dict(workflow_path=workflow_path)
     with open(jsonfile, "w") as fj:

--- a/niflow_manager/cli/build.py
+++ b/niflow_manager/cli/build.py
@@ -51,6 +51,7 @@ def neurodocker_dict(workflow_path):
             raise Exception(f"{key} is not a valid key, must be "
                             f"from the list {VALID_DOCKER_KEYS}")
         instructions.append(this_instruction)
+    instructions.insert(1, ("install", ["git"]))
 
     # adding post build part
     post_build = params.get("post_build", {})
@@ -58,7 +59,8 @@ def neurodocker_dict(workflow_path):
         # if post build not provided, it will use the default one that installs niflow-manager
         # and the package (after coping it first)
         post_build["copy"] = [".", "/nfm"]
-        post_build["miniconda"] = {"pip_install": ["niflow-manager", "/nfm/package/"]}
+        post_build["miniconda"] = {"pip_install": ["https://github.com/djarecka/niflow-manager/tarball/new_testkraken"]}
+        post_build["run_bash"] = "/opt/miniconda-latest/envs/testkraken/bin/nfm install /nfm/package/"
 
     for key, spec in post_build.items():
         if key == "miniconda":

--- a/niflow_manager/cli/build.py
+++ b/niflow_manager/cli/build.py
@@ -70,9 +70,7 @@ def neurodocker_dict(workflow_path):
         post_build["copy"] = [".", "/nfm"]
         # TODO should be updated and the git could be removed
         post_build["miniconda"] = {
-            "pip_install": [
-                "https://github.com/djarecka/niflow-manager/tarball/new_testkraken"
-            ]
+            "pip_install": ["https://github.com/niflows/niflow-manager/tarball/master"]
         }
         # installing niflow
         post_build[

--- a/niflow_manager/cli/install.py
+++ b/niflow_manager/cli/install.py
@@ -7,4 +7,4 @@ import click
 @click.argument("workflow_path", type=click.Path(), default=".")
 def install(workflow_path):
     print(f"installing {workflow_path}")
-    sp.check_call([sys.executable, "-m", "pip", "install", f"{workflow_path}"])
+    sp.check_call([sys.executable, "-m", "pip", "install", f"{workflow_path}/package"])

--- a/niflow_manager/cli/install.py
+++ b/niflow_manager/cli/install.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python3
+import subprocess as sp
+import sys
+import click
+
+
+@click.argument("workflow_path", type=click.Path(), default=".")
+def install(workflow_path):
+    print(f"installing {workflow_path}")
+    sp.check_call([sys.executable, "-m", "pip", "install", f"{workflow_path}"])

--- a/niflow_manager/cli/main.py
+++ b/niflow_manager/cli/main.py
@@ -18,25 +18,33 @@ main.command()(init)
 
 
 @main.command()
-@click.argument('workflow_path', type=click.Path(), default='.')
+@click.argument("workflow_path", type=click.Path(), default=".")
 def install(workflow_path):
     print(f"installing {workflow_path}")
-    sp.check_call([sys.executable, '-m', 'pip', 'install', f'{workflow_path}'])
+    sp.check_call([sys.executable, "-m", "pip", "install", f"{workflow_path}"])
 
 
 @main.command()
-@click.argument('workflow_path', type=click.Path(), default='.')
-@click.option('-w', '--working-dir', type=click.Path(),
-              help="Working directory, default is a temporary directory.")
+@click.argument("workflow_path", type=click.Path(), default=".")
+@click.option(
+    "-w",
+    "--working-dir",
+    type=click.Path(),
+    help="Working directory, default is a temporary directory.",
+)
 def test(workflow_path, working_dir=None):
-    print(f'testing {workflow_path}')
+    print(f"testing {workflow_path}")
     testkraken_specs(workflow_path=Path(workflow_path))
     testkraken_run(workflow_path=workflow_path, working_dir=working_dir)
 
 
-@click.argument('workflow_path', type=click.Path(), default='.')
-@click.option('-w', '--working-dir', type=click.Path(),
-              help="Working directory, default is a temporary directory.")
+@click.argument("workflow_path", type=click.Path(), default=".")
+@click.option(
+    "-w",
+    "--working-dir",
+    type=click.Path(),
+    help="Working directory, default is a temporary directory.",
+)
 @main.command()
 def build(workflow_path, working_dir=None):
     print("build", workflow_path)

--- a/niflow_manager/cli/main.py
+++ b/niflow_manager/cli/main.py
@@ -1,11 +1,10 @@
-import sys
 import click
-from pathlib import Path
-import subprocess as sp
+
 from .. import __version__
 from .init import init
-from .test import testkraken_specs, testkraken_run
-from .build import docker_image
+from .install import install
+from .build import build
+from .test import test
 
 
 @click.group()
@@ -16,36 +15,8 @@ def main():
 
 main.command()(init)
 
+main.command()(install)
 
-@main.command()
-@click.argument("workflow_path", type=click.Path(), default=".")
-def install(workflow_path):
-    print(f"installing {workflow_path}")
-    sp.check_call([sys.executable, "-m", "pip", "install", f"{workflow_path}"])
+main.command()(build)
 
-
-@main.command()
-@click.argument("workflow_path", type=click.Path(), default=".")
-@click.option(
-    "-w",
-    "--working-dir",
-    type=click.Path(),
-    help="Working directory, default is a temporary directory.",
-)
-def test(workflow_path, working_dir=None):
-    print(f"testing {workflow_path}")
-    testkraken_specs(workflow_path=Path(workflow_path))
-    testkraken_run(workflow_path=workflow_path, working_dir=working_dir)
-
-
-@click.argument("workflow_path", type=click.Path(), default=".")
-@click.option(
-    "-w",
-    "--working-dir",
-    type=click.Path(),
-    help="Working directory, default is a temporary directory.",
-)
-@main.command()
-def build(workflow_path, working_dir=None):
-    print("build", workflow_path)
-    docker_image(workflow_path=workflow_path, working_dir=working_dir)
+main.command()(test)

--- a/niflow_manager/cli/main.py
+++ b/niflow_manager/cli/main.py
@@ -1,7 +1,9 @@
 import click
+from pathlib import Path
 import subprocess as sp
 from .. import __version__
 from .init import init
+from .test import testkraken_specs, testkraken_run
 
 
 @click.group()
@@ -24,13 +26,9 @@ def install():
               help="Working directory, default is a temporary directory.")
 
 def test(workflow_path, working_dir=None):
-    #path, full_name, organization, workflow = normalize_path(name)
     print(f'testing {workflow_path}')
-    #path.mkdir(parents=True, exist_ok=True)
-    if working_dir:
-        sp.run(['testkraken', str(workflow_path), "-w", working_dir], check=True)
-    else:
-        sp.run(['testkraken', str(workflow_path)], check=True)
+    testkraken_specs(workflow_path=Path(workflow_path))
+    testkraken_run(workflow_path=workflow_path, working_dir=working_dir)
 
 
 

--- a/niflow_manager/cli/main.py
+++ b/niflow_manager/cli/main.py
@@ -1,9 +1,11 @@
+import sys
 import click
 from pathlib import Path
 import subprocess as sp
 from .. import __version__
 from .init import init
 from .test import testkraken_specs, testkraken_run
+from .build import docker_image
 
 
 @click.group()
@@ -16,22 +18,26 @@ main.command()(init)
 
 
 @main.command()
-def install():
-    print("install command not yet implemented")
+@click.argument('workflow_path', type=click.Path(), default='.')
+def install(workflow_path):
+    print(f"installing {workflow_path}")
+    sp.check_call([sys.executable, '-m', 'pip', 'install', f'{workflow_path}'])
 
 
 @main.command()
 @click.argument('workflow_path', type=click.Path(), default='.')
 @click.option('-w', '--working-dir', type=click.Path(),
               help="Working directory, default is a temporary directory.")
-
 def test(workflow_path, working_dir=None):
     print(f'testing {workflow_path}')
     testkraken_specs(workflow_path=Path(workflow_path))
     testkraken_run(workflow_path=workflow_path, working_dir=working_dir)
 
 
-
+@click.argument('workflow_path', type=click.Path(), default='.')
+@click.option('-w', '--working-dir', type=click.Path(),
+              help="Working directory, default is a temporary directory.")
 @main.command()
-def build():
-    print("build command not yet implemented")
+def build(workflow_path, working_dir=None):
+    print("build", workflow_path)
+    docker_image(workflow_path=workflow_path, working_dir=working_dir)

--- a/niflow_manager/cli/main.py
+++ b/niflow_manager/cli/main.py
@@ -1,4 +1,5 @@
 import click
+import subprocess as sp
 from .. import __version__
 from .init import init
 
@@ -18,8 +19,19 @@ def install():
 
 
 @main.command()
-def test():
-    print("test command not yet implemented")
+@click.argument('workflow_path', type=click.Path(), default='.')
+@click.option('-w', '--working-dir', type=click.Path(),
+              help="Working directory, default is a temporary directory.")
+
+def test(workflow_path, working_dir=None):
+    #path, full_name, organization, workflow = normalize_path(name)
+    print(f'testing {workflow_path}')
+    #path.mkdir(parents=True, exist_ok=True)
+    if working_dir:
+        sp.run(['testkraken', str(workflow_path), "-w", working_dir], check=True)
+    else:
+        sp.run(['testkraken', str(workflow_path)], check=True)
+
 
 
 @main.command()

--- a/niflow_manager/cli/test.py
+++ b/niflow_manager/cli/test.py
@@ -21,7 +21,7 @@ def testkraken_specs(workflow_path):
         # if post build not provided, it will use he default one that installs niflow-manager
         # and the package (after coping it first)
         params_tkraken["post_build"] = {}
-        params_tkraken["post_build"]["copy"] =  [".", "/nfm"]
+        params_tkraken["post_build"]["copy"] = [".", "/nfm"]
         params_tkraken["post_build"]["miniconda"] = {"pip_install": ["niflow-manager", "/nfm/package/"]}
 
     with (workflow_path / 'parameters.yaml').open("w") as f:

--- a/niflow_manager/cli/test.py
+++ b/niflow_manager/cli/test.py
@@ -10,8 +10,8 @@ def testkraken_specs(workflow_path):
     with (workflow_path / "spec.yml").open() as f:
         params = yaml.safe_load(f)
 
-    # everything what is in nfm_test, should be added
-    params_tkraken = params["nfm_test"]
+    # everything what is in test, should be added
+    params_tkraken = params["test"]
     fixed_envs_tkraken = params_tkraken.get("fixed_env", [])
     # requiremnts should be one of the fixed_env
     fixed_envs_tkraken.append(params["requirements"])

--- a/niflow_manager/cli/test.py
+++ b/niflow_manager/cli/test.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+import subprocess as sp
+import yaml
+
+
+def testkraken_specs(workflow_path):
+    """reading spec.yml and creating testkraken yml file"""
+    with (workflow_path / 'spec.yml').open() as f:
+        params = yaml.safe_load(f)
+
+    # everything what is in nfm_test, should be added
+    params_tkraken = params["nfm_test"]
+    fixed_envs_tkraken = params_tkraken.get("fixed_env", [])
+    # requiremnts should be one of the fixed_env
+    fixed_envs_tkraken.append(params["requirements"])
+    params_tkraken["fixed_env"] = fixed_envs_tkraken
+
+    if params.get("post_build", None):
+        params_tkraken["post_build"] = params["post_build"]
+    else:
+        # if post build not provided, it will use he default one that installs niflow-manager
+        # and the package (after coping it first)
+        params_tkraken["post_build"] = {}
+        params_tkraken["post_build"]["copy"] =  [".", "/nfm"]
+        params_tkraken["post_build"]["miniconda"] = {"pip_install": ["niflow-manager", "/nfm/package/"]}
+
+    with (workflow_path / 'parameters.yaml').open("w") as f:
+        yaml.dump(params_tkraken, f, default_flow_style=False, sort_keys=False)
+
+
+def testkraken_run(workflow_path, working_dir=None):
+    if working_dir:
+        sp.run(['testkraken', workflow_path, "-w", working_dir], check=True)
+    else:
+        sp.run(['testkraken', workflow_path], check=True)

--- a/niflow_manager/cli/test.py
+++ b/niflow_manager/cli/test.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 import subprocess as sp
 import yaml
+from pathlib import Path
+import click
 
 
 def testkraken_specs(workflow_path):
@@ -35,3 +37,16 @@ def testkraken_run(workflow_path, working_dir=None):
         sp.run(["testkraken", workflow_path, "-w", working_dir], check=True)
     else:
         sp.run(["testkraken", workflow_path], check=True)
+
+
+@click.argument("workflow_path", type=click.Path(), default=".")
+@click.option(
+    "-w",
+    "--working-dir",
+    type=click.Path(),
+    help="Working directory, default is a temporary directory.",
+)
+def test(workflow_path, working_dir=None):
+    print(f"testing {workflow_path}")
+    testkraken_specs(workflow_path=Path(workflow_path))
+    testkraken_run(workflow_path=workflow_path, working_dir=working_dir)

--- a/niflow_manager/cli/test.py
+++ b/niflow_manager/cli/test.py
@@ -26,7 +26,7 @@ def testkraken_specs(workflow_path):
             "pip_install": ["niflow-manager", "/nfm/package/"]
         }
 
-    with (workflow_path / "parameters.yaml").open("w") as f:
+    with (workflow_path / "testkraken_spec.yml").open("w") as f:
         yaml.dump(params_tkraken, f, default_flow_style=False, sort_keys=False)
 
 

--- a/niflow_manager/cli/test.py
+++ b/niflow_manager/cli/test.py
@@ -13,8 +13,8 @@ def testkraken_specs(workflow_path):
     # everything what is in test, should be added
     params_tkraken = params["test"]
     fixed_envs_tkraken = params_tkraken.get("fixed_env", [])
-    # requiremnts should be one of the fixed_env
-    fixed_envs_tkraken.append(params["requirements"])
+    # required_env from the build part should be one of the fixed_env
+    fixed_envs_tkraken.append(params["build"]["required_env"])
     params_tkraken["fixed_env"] = fixed_envs_tkraken
 
     if params.get("post_build", None):

--- a/niflow_manager/cli/test.py
+++ b/niflow_manager/cli/test.py
@@ -5,7 +5,7 @@ import yaml
 
 def testkraken_specs(workflow_path):
     """reading spec.yml and creating testkraken yml file"""
-    with (workflow_path / 'spec.yml').open() as f:
+    with (workflow_path / "spec.yml").open() as f:
         params = yaml.safe_load(f)
 
     # everything what is in nfm_test, should be added
@@ -22,14 +22,16 @@ def testkraken_specs(workflow_path):
         # and the package (after coping it first)
         params_tkraken["post_build"] = {}
         params_tkraken["post_build"]["copy"] = [".", "/nfm"]
-        params_tkraken["post_build"]["miniconda"] = {"pip_install": ["niflow-manager", "/nfm/package/"]}
+        params_tkraken["post_build"]["miniconda"] = {
+            "pip_install": ["niflow-manager", "/nfm/package/"]
+        }
 
-    with (workflow_path / 'parameters.yaml').open("w") as f:
+    with (workflow_path / "parameters.yaml").open("w") as f:
         yaml.dump(params_tkraken, f, default_flow_style=False, sort_keys=False)
 
 
 def testkraken_run(workflow_path, working_dir=None):
     if working_dir:
-        sp.run(['testkraken', workflow_path, "-w", working_dir], check=True)
+        sp.run(["testkraken", workflow_path, "-w", working_dir], check=True)
     else:
-        sp.run(['testkraken', workflow_path], check=True)
+        sp.run(["testkraken", workflow_path], check=True)

--- a/niflow_manager/cli/tests/test_main.py
+++ b/niflow_manager/cli/tests/test_main.py
@@ -1,5 +1,6 @@
 import pytest
 from click.testing import CliRunner
+from pathlib import Path
 from .. import main
 
 
@@ -15,3 +16,26 @@ def test_commads_help(command):
     runner = CliRunner()
     result = runner.invoke(main, [command, "--help"])
     assert result.exit_code == 0
+
+
+def test_init_build_python():
+    """ initilize a niflow for python and build a container using the default spec"""
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        res_init = runner.invoke(
+            main, ["init", "--language", "python", "wf"], "\n".join(["org", "wf", "y"])
+        )
+        niflow_path = Path.cwd() / "niflow-org-wf"
+        spec_path = niflow_path / "spec.yml"
+        assert res_init.exit_code == 0
+        assert spec_path.exists()
+
+        # uncommenting the spec file
+        with spec_path.open() as f:
+            spec_orig = f.readlines()
+        with spec_path.open(mode="w") as f:
+            for line in spec_orig:
+                f.write(line[1:])
+
+        res_build = runner.invoke(main, ["build", str(niflow_path)])
+        assert res_build.exit_code == 0

--- a/niflow_manager/cli/tests/test_main.py
+++ b/niflow_manager/cli/tests/test_main.py
@@ -35,7 +35,9 @@ def test_init_build_python():
             spec_orig = f.readlines()
         with spec_path.open(mode="w") as f:
             for line in spec_orig:
-                f.write(line[1:])
+                # removing afni and fsl installation to shorten the test
+                if not ("fsl" in line or "afni" in line or "version" in line):
+                    f.write(line[1:])
 
         res_build = runner.invoke(main, ["build", str(niflow_path)])
         assert res_build.exit_code == 0

--- a/niflow_manager/cli/tests/test_main.py
+++ b/niflow_manager/cli/tests/test_main.py
@@ -11,8 +11,8 @@ def test_utility_options(option):
 
 
 @pytest.mark.parametrize("command", ["test", "install", "build"])
-def test_unimplemented(command):
+def test_commads_help(command):
     runner = CliRunner()
-    result = runner.invoke(main, [command])
+    result = runner.invoke(main, [command, "--help"])
     assert result.exit_code == 0
-    assert "not yet implemented" in result.stdout
+

--- a/niflow_manager/cli/tests/test_main.py
+++ b/niflow_manager/cli/tests/test_main.py
@@ -15,4 +15,3 @@ def test_commads_help(command):
     runner = CliRunner()
     result = runner.invoke(main, [command, "--help"])
     assert result.exit_code == 0
-

--- a/niflow_manager/data/templates/base/.circleci/config.yml
+++ b/niflow_manager/data/templates/base/.circleci/config.yml
@@ -1,0 +1,31 @@
+version: 2
+jobs:
+  build:
+    machine:
+      image: circleci/classic:201710-02
+    working_directory: /home/circleci/nfm_tests
+    steps:
+      - checkout:
+          path: /home/circleci/nfm_tests
+      - run:
+          name: Change to Python 3.7+ and install python dependencies
+          command: |
+            curl -fsSLO https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
+            bash Miniconda3-latest-Linux-x86_64.sh -b -p ~/conda
+            rm Miniconda3-latest-Linux-x86_64.sh
+            echo "export PATH=~/conda/bin:$PATH" >> ~/.bashrc
+            source ~/.bashrc
+            conda config --system --prepend channels conda-forge
+            conda update -n base -yq conda
+            conda update -yq --all
+            pip install git+https://github.com/djarecka/niflow-manager.git@new_testkraken
+            #pip install --no-cache-dir -e /home/circleci/nfm_tests[dev]
+
+      - run:
+          name: Run tests
+          no_output_timeout: 60m
+          command: |
+            source ~/.bashrc
+            nfm test /home/circleci/nfm_tests -w /home/circleci/nfm_tests/outputs/{FULLNAME}
+      - store_artifacts:
+          path: /home/circleci/nfm_tests

--- a/niflow_manager/data/templates/base/spec.yml
+++ b/niflow_manager/data/templates/base/spec.yml
@@ -1,50 +1,44 @@
-#  # requirement for the environment needed to run the analyses
-#requirements:
-#  # example below, see full Neurodocker spcification: https://github.com/ReproNim/neurodocker#supported-software
-#  base:
-#    image: debian:stretch
-#    pkg-manager: apt
+# requirement for the environment needed to run the analyses,
+# it will be used to create an image with `nfm build`
+# it will be also used as an additional environment during testing with `nfm test`
+requirements:
+# example below, see full Neurodocker spcification: https://github.com/ReproNim/neurodocker#supported-software
+  base:
+    image: debian:stretch
+    pkg-manager: apt
+  miniconda:
+    conda_install: [python=3.7, nipype]
 #  fsl:
 #    version: 5.0.10
 #  afni:
 #    version: latest
-#  miniconda:
-#    conda_install: [python=3.7]
 #
-#  # test specification
-#nfm_test:
-#  # default place for place the data, can be changed
-#  data:
-#    type: workflow_path
-#    location: test/data
-#  # default place to place the scripts, can be changed
-#  scripts:
-#    test/scripts
-#  # additional (to the one defined in the requirements) environments for testing
-#  env:
-#    base:
-#    - image: debian:stretch
-#      pkg-manager: apt
-#    fsl:
-#    - version: 5.0.10
-#    afni:
-#    - version: latest
-#    miniconda:
-#    - conda_install: [python=2.7]
-#  # specification for the analysis that will be run and the needed input (input files expected to be in the data dir),
-#  # if script is provided, it should be in the scripts directory
-#  analysis:
-#    inputs:
-#     - type: File
-#       value: sub-01_ses-test_T1w.nii.gz
-#     - type: str
-#       name: out_name
-#       value: sub-01_out.nii.gz
-#       output_file: True
-#    command: niflow-coco2019-unifize_and_skullstrip
+# test specification
+test:
+  # default location for data in the niflows is test/data in the workflow path
+  data:
+    type: workflow_path
+    location: test/data
+  # default location for scripts in the niflows is test/scripts in the workflow path
+  scripts: test/scripts
+
+  # additional (to the one defined in the requirements) environments for testing
+  # a simple example that has only one base image and one miniconda environment
+  env:
+    base:
+    - image: debian:stretch
+      pkg-manager: apt
+    miniconda:
+    - conda_install: [python=3.5, nipype]
+
+  # specification for the analysis that will be run and the needed input (input files expected to be in the data dir),
+  # if script is provided, it should be in the scripts directory
+  analysis:
+    inputs: []
+    command: niflow-{ORGANIZATION}-{WORKFLOW}
 #  # specification for the output testing: script should be either in the scripts dir or from TestKraken
 #  # file should be an output name and the reference one should be in the data dir
-#  tests:
+  tests: []
 #  - file: out_name
 #    name: regr1
 #    script: test_obj_eq.py

--- a/niflow_manager/data/templates/base/spec.yml
+++ b/niflow_manager/data/templates/base/spec.yml
@@ -1,18 +1,23 @@
-# requirement for the environment needed to run the analyses,
-# it will be used to create an image with `nfm build`
-# it will be also used as an additional environment during testing with `nfm test`
-requirements:
-# example below, see full Neurodocker spcification: https://github.com/ReproNim/neurodocker#supported-software
-  base:
-    image: debian:stretch
-    pkg-manager: apt
-  miniconda:
-    conda_install: [python=3.7, nipype]
-#  fsl:
-#    version: 5.0.10
-#  afni:
-#    version: latest
+# the build part will be used to create an image with `nfm build`
+# required_env is the required entry and it specifies the environment needed to run the analyses,
+# required_env will be also used as an additional environment during testing with `nfm test`
+# entrypoint - an optional entrypoint for the container (niflow-{ORGANIZATION}-{WORKFLOW} is the default value)
+build:
+  # example below, see full Neurodocker spcification: https://github.com/ReproNim/neurodocker#supported-software
+  required_env:
+    base:
+      image: debian:stretch
+      pkg-manager: apt
+    miniconda:
+      conda_install: [python=3.7, nipype]
+#    fsl:
+#      version: 5.0.10
+#    afni:
+#      version: latest
 #
+# optional entrypoint, for python, the default value is
+#  entrypoint: /opt/miniconda-latest/envs/testkraken/bin/niflow-{ORGANIZATION}-{WORKFLOW}
+
 # test specification
 test:
   # default location for data in the niflows is test/data in the workflow path
@@ -22,7 +27,7 @@ test:
   # default location for scripts in the niflows is test/scripts in the workflow path
   scripts: test/scripts
 
-  # additional (to the one defined in the requirements) environments for testing
+  # additional (to the one defined in the build.required_env) environments for testing
   # a simple example that has only one base image and one miniconda environment
   env:
     base:

--- a/niflow_manager/data/templates/base/spec.yml
+++ b/niflow_manager/data/templates/base/spec.yml
@@ -1,0 +1,50 @@
+#  # requirement for the environment needed to run the analyses
+#requirements:
+#  # example below, see full Neurodocker spcification: https://github.com/ReproNim/neurodocker#supported-software
+#  base:
+#    image: debian:stretch
+#    pkg-manager: apt
+#  fsl:
+#    version: 5.0.10
+#  afni:
+#    version: latest
+#  miniconda:
+#    conda_install: [python=3.7, nipype]
+#
+#  # test specification
+#nfm_test:
+#  # default place for place the data, can be changed
+#  data:
+#    type: workflow_path
+#    location: test/data
+#  # default place to place the scripts, can be changed
+#  scripts:
+#    test/scripts
+#  # additional (to the one defined in the requirements) environments for testing
+#  env:
+#    base:
+#    - image: debian:stretch
+#      pkg-manager: apt
+#    fsl:
+#    - version: 5.0.10
+#    afni:
+#    - version: latest
+#    miniconda:
+#    - conda_install: [python=2.7, nipype]
+#  # specification for the analysis that will be run and the needed input (input files expected to be in the data dir),
+#  # if script is provided, it should be in the scripts directory
+#  analysis:
+#    inputs:
+#     - type: File
+#       value: sub-01_ses-test_T1w.nii.gz
+#     - type: str
+#       name: out_name
+#       value: sub-01_out.nii.gz
+#       output_file: True
+#    command: niflow-coco2019-unifize_and_skullstrip
+#  # specification for the output testing: script should be either in the scripts dir or from TestKraken
+#  # file should be an output name and the reference one should be in the data dir
+#  tests:
+#  - file: out_name
+#    name: regr1
+#    script: test_obj_eq.py

--- a/niflow_manager/data/templates/base/spec.yml
+++ b/niflow_manager/data/templates/base/spec.yml
@@ -9,7 +9,7 @@
 #  afni:
 #    version: latest
 #  miniconda:
-#    conda_install: [python=3.7, nipype]
+#    conda_install: [python=3.7]
 #
 #  # test specification
 #nfm_test:
@@ -30,7 +30,7 @@
 #    afni:
 #    - version: latest
 #    miniconda:
-#    - conda_install: [python=2.7, nipype]
+#    - conda_install: [python=2.7]
 #  # specification for the analysis that will be run and the needed input (input files expected to be in the data dir),
 #  # if script is provided, it should be in the scripts directory
 #  analysis:

--- a/niflow_manager/data/templates/base/test/README.md
+++ b/niflow_manager/data/templates/base/test/README.md
@@ -1,9 +1,13 @@
-The test directory may contain three subdirectories:
+The test directory may contain two subdirectories:
 
-* `scripts` - locally-defined tests
-* `inputs` - Data files and input parameters for applying tests
-* `expected` - Expected results of tests
+* `scripts` - analyses for testing and locally-defined tests
+* `data` - data files that are needed for analyses and testing
+(i.e. reference output).
 
-The `inputs` and `expected` directories may contain large files and may be better handled
+This is the default place to keep these directories, but in `spec.yml`
+the paths can be overwritten.
+
+The `data` directory may contain large files and may be better handled
 via [git submodules](https://git-scm.com/book/en/v2/Git-Tools-Submodules) and
 [DataLad](http://docs.datalad.org) than by directly including them in the repository.
+(not implemented in TestKraken yet!)

--- a/niflow_manager/data/templates/base/test/data/README.md
+++ b/niflow_manager/data/templates/base/test/data/README.md
@@ -1,0 +1,2 @@
+This is the default place for the input and reference data files,
+the path can be overwritten in the `spec.yml` file.

--- a/niflow_manager/data/templates/base/test/scripts/README.md
+++ b/niflow_manager/data/templates/base/test/scripts/README.md
@@ -1,0 +1,3 @@
+This is the default place to keep the scripts files for:
+- analyses that should be tested,
+- tests that will be used for comparing the output.

--- a/niflow_manager/data/templates/python/package/setup.cfg
+++ b/niflow_manager/data/templates/python/package/setup.cfg
@@ -18,7 +18,8 @@ classifiers =
 [options]
 packages = find:
 # Place any Python dependencies here
-install_requires = 
+install_requires =
+    nipype
 ## For very fine-grained control over included files, uncomment the following line and
 ## create a MANIFEST.in file. (https://packaging.python.org/guides/using-manifest-in/)
 # include_package_data = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 Click
+pyyaml
+neurodocker

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,0 @@
-Click
-pyyaml
-neurodocker

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ install_requires =
     Click
     pyyaml
     neurodocker
-    testkraken @ git+https://github.com/ReproNim/testkraken.git@master
+    testkraken
 include_package_data = True
 
 [options.entry_points]

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,11 @@ classifiers =
 
 [options]
 packages = find:
-install_requires = Click
+install_requires =
+    Click
+    pyyaml
+    neurodocker
+    testkraken @ git+https://github.com/ReproNim/testkraken.git@master
 include_package_data = True
 
 [options.entry_points]


### PR DESCRIPTION
- `nfm tests` uses testkraken (see https://github.com/niflows/coco2019-unifize_and_skullstrip/pull/2)
- `nfm build` uses neurodocker to create a dockerfile and docker build (many functions just copied from testkraken)
- `nfm install` works only for python packages - simple pip install